### PR TITLE
feat(api): add HeadBucket endpoint and tighten object route matching

### DIFF
--- a/docs/S3_API_IMPLEMENTATION.md
+++ b/docs/S3_API_IMPLEMENTATION.md
@@ -68,6 +68,14 @@ The S3 Encryption Gateway must maintain full compatibility with the Amazon S3 AP
   - `GET /{bucket}?delimiter=...` (ListObjects with delimiter)
 - **Implementation**: Pass-through to backend, no modification needed
 
+#### Head Bucket
+- **Endpoint**: `HEAD /{bucket}`
+- **Implementation**:
+  - Validate bucket-level existence/access against backend
+  - Return `200 OK` with empty body on success
+  - Return translated S3 error codes (`NoSuchBucket`, `AccessDenied`, etc.) on failure
+
+
 #### Head Object
 - **Endpoint**: `HEAD /{bucket}/{key}`
 - **Implementation**:


### PR DESCRIPTION
## Summary
This PR adds support for the S3 `HeadBucket` operation and fixes route matching ambiguity for object-level endpoints.

## Why
Some S3 clients and integrations expect `HEAD /{bucket}` to validate bucket existence/accessibility.  
Before this change, the gateway did not explicitly implement this operation and object routes allowed empty keys (`{key:.*}`), which could cause trailing-slash routing edge cases.

## What changed
1. Added `HEAD /{bucket}` route and `handleHeadBucket` handler.
2. Implemented backend validation via a minimal list request (`MaxKeys: 1`) and translated backend errors to S3-compatible responses (`NoSuchBucket`, `AccessDenied`, etc.).
3. Updated object/multipart route key matchers from `{key:.*}` to `{key:.+}` to require non-empty object keys.
4. Added unit tests:
   - `TestHandler_HandleHeadBucket`
   - `TestHandler_HandleHeadBucket_NotFound`
   - `TestHandler_HeadBucketTrailingSlash_NotRoutedAsHeadObject`
5. Documented HeadBucket behavior in `docs/S3_API_IMPLEMENTATION.md`.

## Behavior impact
- `HEAD /{bucket}` now returns:
  - `200 OK` with empty body on success
  - S3-compatible error status/body on failure
- Object routes no longer match empty keys, so `HEAD /bucket/` is not treated as `HeadObject`.

## Compatibility and risk
- Backward-compatible for valid object-key requests.
- Route tightening intentionally rejects empty-key paths that were previously ambiguous.

## Validation
- Added/updated unit tests in `internal/api/handlers_test.go`.
- Note: I could not run `go test` in this environment because `go` is not installed.
