### PR TITLE
fix: make PutObject bodies rewindable so backend retries work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Retryable `PutObject` bodies (ADR 0010):** A chunked-encrypted upload hands
+  `PutObject` a streaming ciphertext reader, which is not an `io.Seeker`. The AWS
+  SDK rewinds the request body before a retry, so on that path every retryable
+  backend failure aborted with `failed to rewind transport stream for retry,
+  request stream is not seekable` instead of being retried, leaving the backend
+  retry policy inert on the one path that carries every ordinary write. A
+  transient backend `500` therefore surfaced to the client as a hard error;
+  against Backblaze B2 this was measured at roughly 3% of uploads. `PutObject`
+  bodies of known length now go through the same bounded `SeekableBody` wrapper
+  `UploadPart` already uses, capped by `server.max_part_buffer`, so the SDK can
+  replay them. Bodies of unknown length keep the streaming path unchanged. As a
+  consequence of the body becoming seekable, these requests now also carry
+  `Content-MD5` and a signed payload rather than `UNSIGNED-PAYLOAD`. Added unit
+  coverage for the rewind contract in both directions and a
+  `PERF2_Retry_503_ChunkedPut` conformance case — the existing retry conformance
+  tests all ran with chunking disabled, which yields a seekable body and never
+  exercised rewind-on-retry.
+
 ## [0.11.10] — 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   against Backblaze B2 this was measured at roughly 3% of uploads. `PutObject`
   bodies of known length now go through the same bounded `SeekableBody` wrapper
   `UploadPart` already uses, capped by `server.max_part_buffer`, so the SDK can
-  replay them. Bodies of unknown length keep the streaming path unchanged. As a
+  replay them. A declared `Content-Length: 0` counts as a known length: it was
+  previously indistinguishable from an absent header, which sent a valid
+  zero-byte upload down the unknown-length streaming path. Bodies of genuinely
+  unknown length keep the streaming path unchanged. As a
   consequence of the body becoming seekable, these requests now also carry
   `Content-MD5` and a signed payload rather than `UNSIGNED-PAYLOAD`. Added unit
   coverage for the rewind contract in both directions and a

--- a/docs/adr/0010-backend-retry-policy.md
+++ b/docs/adr/0010-backend-retry-policy.md
@@ -139,6 +139,28 @@ transient-503 class of faults the suite exercises today. Reference:
 **Incompatible.** The gateway is a single-backend proxy; hedging to
 alternative backends requires a backend pool that does not exist.
 
+## Addendum: retries require a rewindable body
+
+A retry replays the request, so the AWS SDK rewinds the body before the second
+attempt (`aws/retry/middleware.go`). A body that is not an `io.Seeker` cannot be
+rewound, and the SDK fails the operation with `failed to rewind transport stream
+for retry, request stream is not seekable` rather than retrying. Every policy
+decision above — classification, backoff, `max_attempts` — is therefore
+conditional on the caller supplying a seekable body, which this ADR originally
+left unstated.
+
+This is not hypothetical: `handlePutObject` streams chunked ciphertext, so the
+policy was inert on the main write path until the body was buffered. Callers
+satisfy the contract with `s3.NewSeekableBody`, bounded by
+`server.max_part_buffer` (see the ADR 0006 addendum and
+`docs/plans/V0.6-PERF-1-plan.md` §4.4). The remaining non-rewindable case is a
+body of unknown length, which stays single-attempt by design.
+
+Two consequences worth noting when reading the metrics: a give-up recorded
+against a non-seekable body never reached the network on its second attempt, and
+a seekable body also enables `Content-MD5` and payload signing in
+`s3Client.PutObject`, which key off the same type assertion.
+
 ## References
 
 1. *Cloud Native Go, 2nd Ed.* (Matthew A. Titmus, O'Reilly 2024), ch. 9

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1708,17 +1708,23 @@ func (h *Handler) handlePutObject(w http.ResponseWriter, r *http.Request) {
 	// sending to S3.  For AWS Chunked Uploads we use
 	// x-amz-decoded-content-length as that represents the actual object
 	// size, while the HTTP Content-Length includes chunk overhead.
+	// haveContentLength distinguishes a declared length from an absent one:
+	// originalBytes is 0 for both "Content-Length: 0" and no header at all, but
+	// only the latter is an unknown-length stream.
 	var originalBytes int64
+	var haveContentLength bool
 	decodedLen := r.Header.Get("x-amz-decoded-content-length")
 	if decodedLen != "" {
 		metadata["Content-Length"] = decodedLen
-		if v, err := strconv.ParseInt(decodedLen, 10, 64); err == nil {
+		if v, err := strconv.ParseInt(decodedLen, 10, 64); err == nil && v >= 0 {
 			originalBytes = v
+			haveContentLength = true
 		}
 	} else if contentLength := r.Header.Get("Content-Length"); contentLength != "" {
 		metadata["Content-Length"] = contentLength
-		if v, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
+		if v, err := strconv.ParseInt(contentLength, 10, 64); err == nil && v >= 0 {
 			originalBytes = v
+			haveContentLength = true
 		}
 	}
 
@@ -1888,11 +1894,13 @@ func (h *Handler) handlePutObject(w http.ResponseWriter, r *http.Request) {
 	// For legacy (non-chunked) encryption: the encrypted reader is a *bytes.Reader
 	// which reports its own length; contentLengthPtr stays nil so the S3 client
 	// derives it from the reader.
+	// Keyed on haveContentLength, not originalBytes > 0: a declared zero is a
+	// known length and must not be mistaken for an unknown-length stream.
 	var contentLengthPtr *int64
-	if originalBytes > 0 && encMetadata[crypto.MetaEncrypted] != "true" {
+	if haveContentLength && encMetadata[crypto.MetaEncrypted] != "true" {
 		// Bypass / passthrough mode: plaintext is stored as-is.
 		contentLengthPtr = &originalBytes
-	} else if encMetadata[crypto.MetaChunkedFormat] == "true" && originalBytes > 0 {
+	} else if encMetadata[crypto.MetaChunkedFormat] == "true" && haveContentLength {
 		// Determine chunk size from metadata
 		chunkSize := crypto.DefaultChunkSize
 		if csStr, ok := encMetadata[crypto.MetaChunkSize]; ok && csStr != "" {
@@ -1914,14 +1922,15 @@ func (h *Handler) handlePutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// When originalBytes is unknown (e.g. chunked transfer encoding from client
-	// with no Content-Length), wrap the encrypted reader to count ciphertext bytes.
-	// After PutObject, back-calculate the plaintext size and persist it via a
-	// metadata-only copy-to-self. This ensures HeadObject returns the correct
-	// Content-Length so clients can issue correct range requests without the
-	// gateway needing to fetch and decrypt the full object on every range GET.
+	// When the plaintext size is unknown (e.g. chunked transfer encoding from a
+	// client with no Content-Length), wrap the encrypted reader to count
+	// ciphertext bytes. After PutObject, back-calculate the plaintext size and
+	// persist it via a metadata-only copy-to-self. This ensures HeadObject returns
+	// the correct Content-Length so clients can issue correct range requests
+	// without the gateway needing to fetch and decrypt the full object on every
+	// range GET. A declared length needs none of this, zero included.
 	var ciphertextCounter *countingReader
-	if originalBytes == 0 && encMetadata[crypto.MetaChunkedFormat] == "true" {
+	if !haveContentLength && encMetadata[crypto.MetaChunkedFormat] == "true" {
 		ciphertextCounter = newCountingReader(encryptedReader)
 		encryptedReader = ciphertextCounter
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1926,6 +1926,46 @@ func (h *Handler) handlePutObject(w http.ResponseWriter, r *http.Request) {
 		encryptedReader = ciphertextCounter
 	}
 
+	// The SDK rewinds the body to retry, so a non-seekable reader makes every
+	// retryable failure fatal ("failed to rewind transport stream for retry") and
+	// leaves ADR 0010's retry policy inert on this path. Buffer into the bounded
+	// wrapper handleUploadPart uses; see docs/plans/V0.6-PERF-1-plan.md §4.4.
+	//
+	// Gated on a known length that fits. NewSeekableBody has to drain maxBuf+1
+	// bytes before it can report ErrPartTooLarge, and a partially drained source
+	// cannot go back to streaming — so without a length up front, buffering is a
+	// one-way bet on a body that may not fit. Checking the length first makes the
+	// oversize branch unreachable instead of recoverable, which is why there is no
+	// 413 here as there is in handleUploadPart: reaching it would mean our own
+	// ciphertext length estimate was wrong, i.e. a server fault, not a too-large
+	// request. Unknown-length bodies keep streaming and stay single-attempt.
+	if maxBuf := effectiveMaxPartBuffer(h.config); contentLengthPtr != nil && *contentLengthPtr <= maxBuf {
+		if _, seekable := encryptedReader.(io.Seeker); !seekable {
+			sb, sbErr := s3.NewSeekableBody(encryptedReader, maxBuf)
+			if sbErr != nil {
+				h.logger.WithError(sbErr).WithFields(logrus.Fields{
+					"bucket": bucket,
+					"key":    key,
+				}).Error("Failed to buffer encrypted object for upload")
+				s3Err := &S3Error{
+					Code:       "InternalError",
+					Message:    "Failed to prepare object for upload",
+					Resource:   r.URL.Path,
+					HTTPStatus: http.StatusInternalServerError,
+				}
+				s3Err.WriteXML(w)
+				h.metrics.RecordS3Error(r.Context(), "PutObject", bucket, s3Err.Code)
+				h.metrics.RecordHTTPRequest(r.Context(), "PUT", r.URL.Path, s3Err.HTTPStatus, time.Since(start), 0)
+				return
+			}
+			// sb.Len is the exact ciphertext size, so prefer it over the value derived
+			// from plaintext size and per-chunk tag overhead.
+			encryptedReader = sb
+			encLen := sb.Len
+			contentLengthPtr = &encLen
+		}
+	}
+
 	// Upload encrypted object with filtered metadata (streaming)
 	etag, err := s3Client.PutObject(ctx, bucket, key, encryptedReader, s3Metadata, contentLengthPtr, tagging, lockInput, cannedACL, grantFullControl, grantRead, grantReadACP, grantWriteACP)
 	if err != nil {

--- a/internal/api/put_retry_test.go
+++ b/internal/api/put_retry_test.go
@@ -125,6 +125,34 @@ func TestHandlePutObject_Chunked_SurvivesTransientBackend500(t *testing.T) {
 	}
 }
 
+// A declared "Content-Length: 0" is a known length, not an unknown-length
+// stream, so it goes through the same bounded wrapper and is retryable. The two
+// used to be indistinguishable because both left originalBytes at 0, which sent
+// a valid zero-byte upload down the streaming path and made it fail on the first
+// transient backend error.
+func TestHandlePutObject_ZeroLength_SurvivesTransientBackend500(t *testing.T) {
+	srv, backend := faultyPutBackend(1)
+	defer srv.Close()
+	router, _ := newRetryHandler(t, srv.URL, true)
+
+	req := httptest.NewRequest(http.MethodPut, "/test-bucket/empty-key", bytes.NewReader(nil))
+	req.ContentLength = 0
+	req.Header.Set("Content-Length", "0")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 after the backend 500 is retried, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if got := backend.puts.Load(); got != 2 {
+		t.Errorf("expected 2 backend PUT attempts (1 fault + 1 retry), got %d", got)
+	}
+	// A declared length needs no back-calculation, so no copy-to-self fix-up.
+	if got := backend.copies.Load(); got != 0 {
+		t.Errorf("expected no metadata copy-to-self for a declared length, got %d", got)
+	}
+}
+
 // A body with no Content-Length keeps streaming and stays single-attempt: the
 // size is not known up front, so it cannot be checked against max_part_buffer
 // without draining the source, and a drained source cannot go back to streaming.

--- a/internal/api/put_retry_test.go
+++ b/internal/api/put_retry_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cloud37/s3-encryption-gateway/internal/config"
+	"github.com/cloud37/s3-encryption-gateway/internal/crypto"
+	"github.com/cloud37/s3-encryption-gateway/internal/s3"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+// putBackend records what a minimal S3 backend saw: body uploads, and the
+// metadata-only copy-to-self through which the unknown-length path persists the
+// back-calculated plaintext size.
+type putBackend struct {
+	puts       atomic.Int32
+	copies     atomic.Int32
+	copiedSize atomic.Value // string; MetaOriginalSize on the last copy
+}
+
+func (b *putBackend) lastCopiedSize() string {
+	s, _ := b.copiedSize.Load().(string)
+	return s
+}
+
+// faultyPutBackend fails the first faultCount body uploads with a 500 and
+// succeeds afterwards.
+func faultyPutBackend(faultCount int32) (*httptest.Server, *putBackend) {
+	b := &putBackend{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The copy-to-self carries no body, so it is not an upload attempt.
+		if r.Method != http.MethodPut || r.Header.Get("X-Amz-Copy-Source") != "" {
+			if r.Header.Get("X-Amz-Copy-Source") != "" {
+				b.copies.Add(1)
+				b.copiedSize.Store(r.Header.Get("X-Amz-Meta-Encryption-Original-Size"))
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `<CopyObjectResult><ETag>"copy-ok"</ETag></CopyObjectResult>`)
+			return
+		}
+		// Drain the body so the backend observes the whole request, as a real
+		// one would; a retry that never resends is then visibly short.
+		_, _ = io.Copy(io.Discard, r.Body)
+		if b.puts.Add(1) <= faultCount {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `<Error><Code>InternalError</Code><Message>injected</Message></Error>`)
+			return
+		}
+		w.Header().Set("ETag", `"put-ok"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	return srv, b
+}
+
+// newRetryHandler wires the real s3 client (not the mock) to the real handler so
+// the request goes through the SDK middleware, which is the only place the
+// rewind-on-retry contract is exercised.
+func newRetryHandler(t *testing.T, backendURL string, chunked bool) (*mux.Router, *config.Config) {
+	t.Helper()
+	bcfg := &config.BackendConfig{
+		Endpoint:     backendURL,
+		Region:       "us-east-1",
+		AccessKey:    "AKIATEST",
+		SecretKey:    "secrettest",
+		UsePathStyle: true,
+		UseSSL:       false,
+		Retry: config.BackendRetryConfig{
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			Jitter:         "none",
+		},
+	}
+	client, err := s3.NewBackendClient(bcfg)
+	if err != nil {
+		t.Fatalf("NewBackendClient: %v", err)
+	}
+	engine, err := crypto.NewEngineWithChunking([]byte("test-password-retry-123456"), "", nil, chunked, 0)
+	if err != nil {
+		t.Fatalf("NewEngineWithChunking: %v", err)
+	}
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	cfg := newConfigWithMaxPartBuffer(64 << 20)
+	cfg.Backend = *bcfg
+	handler := NewHandlerWithFeatures(client, engine, logger, getTestMetrics(), nil, nil, nil, cfg, nil)
+	router := mux.NewRouter()
+	handler.RegisterRoutes(router)
+	return router, cfg
+}
+
+// A chunked-encrypted PUT produces a streaming, non-seekable ciphertext reader.
+// Without buffering the SDK cannot rewind it, so a single transient backend 500
+// fails the client request outright instead of being retried. This is the
+// regression guard for that: the observed production failure was a ~3% PutObject
+// error rate against a backend whose 500s the retry policy was meant to absorb.
+func TestHandlePutObject_Chunked_SurvivesTransientBackend500(t *testing.T) {
+	srv, backend := faultyPutBackend(1)
+	defer srv.Close()
+	router, _ := newRetryHandler(t, srv.URL, true)
+
+	body := bytes.Repeat([]byte("m"), 4096)
+	req := httptest.NewRequest(http.MethodPut, "/test-bucket/blob-key", bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	// handlePutObject reads the object size from the header, not r.ContentLength.
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 after the backend 500 is retried, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if got := backend.puts.Load(); got != 2 {
+		t.Errorf("expected 2 backend PUT attempts (1 fault + 1 retry), got %d", got)
+	}
+}
+
+// A body with no Content-Length keeps streaming and stays single-attempt: the
+// size is not known up front, so it cannot be checked against max_part_buffer
+// without draining the source, and a drained source cannot go back to streaming.
+// This is the characterisation of that trade-off — it fails if the body is ever
+// buffered here, which would turn the request into 2 attempts and a 200.
+func TestHandlePutObject_UnknownLength_StreamsSingleAttempt(t *testing.T) {
+	srv, backend := faultyPutBackend(1)
+	defer srv.Close()
+	router, _ := newRetryHandler(t, srv.URL, true)
+
+	body := bytes.Repeat([]byte("m"), 4096)
+	req := httptest.NewRequest(http.MethodPut, "/test-bucket/blob-key", bytes.NewReader(body))
+	req.ContentLength = -1
+	req.Header.Del("Content-Length")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected the injected 500 to surface: an unknown-length body is not rewindable, so it cannot be retried")
+	}
+	if got := backend.puts.Load(); got != 1 {
+		t.Errorf("expected the retry to abort before a second request reaches the backend, got %d attempts", got)
+	}
+}
+
+// The unknown-length path measures the ciphertext with ciphertextCounter and
+// back-calculates the plaintext size, persisting it via a metadata-only
+// copy-to-self so HeadObject reports the right Content-Length. That arithmetic
+// had no coverage; this pins it. 4096 plaintext + one 16-byte AEAD tag = 4112
+// ciphertext, which must solve back to 4096.
+func TestHandlePutObject_UnknownLength_RecordsPlaintextSize(t *testing.T) {
+	srv, backend := faultyPutBackend(0)
+	defer srv.Close()
+	router, _ := newRetryHandler(t, srv.URL, true)
+
+	body := bytes.Repeat([]byte("m"), 4096)
+	req := httptest.NewRequest(http.MethodPut, "/test-bucket/blob-key", bytes.NewReader(body))
+	req.ContentLength = -1
+	req.Header.Del("Content-Length")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	if got := backend.copies.Load(); got != 1 {
+		t.Fatalf("expected the metadata copy-to-self that persists the plaintext size, got %d copies", got)
+	}
+	if got := backend.lastCopiedSize(); got != strconv.Itoa(len(body)) {
+		t.Errorf("MetaOriginalSize on the copy = %q, want %q", got, strconv.Itoa(len(body)))
+	}
+}

--- a/internal/s3/put_retry_test.go
+++ b/internal/s3/put_retry_test.go
@@ -1,0 +1,95 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloud37/s3-encryption-gateway/internal/config"
+)
+
+// These tests pin the SDK body contract that ADR 0010's retry policy depends on:
+// a retry replays the body, so the SDK rewinds it first. A body that is not an
+// io.Seeker cannot be rewound and the operation fails instead of retrying. The
+// retryer classifies a 500 as retryable, so only a request driven through the
+// SDK middleware with a real body exposes this. Callers of PutObject must supply
+// a rewindable body — handlePutObject and handleUploadPart use NewSeekableBody.
+
+// nonSeekableReader hides any Seek method on the underlying reader, matching the
+// shape of a streaming ciphertext reader or a plain http.Request.Body.
+type nonSeekableReader struct{ io.Reader }
+
+// buildRetryTestS3Client is buildTestS3Client with a short, unjittered backoff.
+func buildRetryTestS3Client(t *testing.T, transport *countingFaultTransport) Client {
+	t.Helper()
+	cfg := &config.BackendConfig{
+		Endpoint:  "http://localhost:9000",
+		Region:    "us-east-1",
+		AccessKey: "AKIATEST",
+		SecretKey: "secrettest",
+		UseSSL:    false,
+		Retry: config.BackendRetryConfig{
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			Jitter:         "none",
+		},
+	}
+	factory := NewClientFactory(cfg, WithHTTPTransport(transport))
+	c, err := factory.GetClient()
+	if err != nil {
+		t.Fatalf("GetClient() error: %v", err)
+	}
+	return c
+}
+
+// With a rewindable body a transient 500 is absorbed and the caller never sees it.
+func TestS3Client_PutObject_SeekableBody_RetriedAfterTransient500(t *testing.T) {
+	payload := []byte("ciphertext-payload")
+	body, err := NewSeekableBody(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		t.Fatalf("NewSeekableBody: %v", err)
+	}
+
+	tr := &countingFaultTransport{faultStatus: 500, faultCount: 1}
+	client := buildRetryTestS3Client(t, tr)
+
+	_, err = client.PutObject(context.Background(), "bkt", "key", body, nil,
+		&body.Len, "", nil, "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("PutObject with a seekable body must survive one transient 500, got: %v", err)
+	}
+	if tr.called != 2 {
+		t.Errorf("expected 2 backend attempts (1 fault + 1 retry), got %d", tr.called)
+	}
+}
+
+// The negative half, and the reason handlePutObject buffers: the retryer decides
+// to retry, the rewind fails, and the operation fails instead. If this ever
+// starts passing, the buffering in handlePutObject can be revisited.
+func TestS3Client_PutObject_NonSeekableBody_CannotRewind(t *testing.T) {
+	payload := []byte("ciphertext-payload")
+	length := int64(len(payload))
+	body := nonSeekableReader{bytes.NewReader(payload)}
+
+	if _, seekable := interface{}(body).(io.Seeker); seekable {
+		t.Fatal("test body must not be seekable")
+	}
+
+	tr := &countingFaultTransport{faultStatus: 500, faultCount: 1}
+	client := buildRetryTestS3Client(t, tr)
+
+	_, err := client.PutObject(context.Background(), "bkt", "key", body, nil,
+		&length, "", nil, "", "", "", "", "")
+	if err == nil {
+		t.Fatal("expected PutObject to fail: a non-seekable body cannot be rewound for retry")
+	}
+	if !strings.Contains(err.Error(), "rewind") {
+		t.Errorf("expected the SDK rewind error, got: %v", err)
+	}
+	if tr.called != 1 {
+		t.Errorf("expected the retry to abort before a second request reaches the backend, got %d attempts", tr.called)
+	}
+}

--- a/test/conformance/retry_test.go
+++ b/test/conformance/retry_test.go
@@ -23,8 +23,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 
 	internalconfig "github.com/cloud37/s3-encryption-gateway/internal/config"
 	"github.com/cloud37/s3-encryption-gateway/test/harness"
@@ -58,9 +58,9 @@ func startRetryGatewayAt(t *testing.T, backendURL string) *harness.Gateway {
 			cfg.Backend.UsePathStyle = true
 			cfg.Backend.UseSSL = false
 			// Speed up: keep 3 max attempts but use very small backoff.
-			cfg.Backend.Retry.InitialBackoff = 1e6  // 1 ms in nanoseconds
-			cfg.Backend.Retry.MaxBackoff = 10e6     // 10 ms
-			cfg.Backend.Retry.Jitter = "none"       // deterministic
+			cfg.Backend.Retry.InitialBackoff = 1e6 // 1 ms in nanoseconds
+			cfg.Backend.Retry.MaxBackoff = 10e6    // 10 ms
+			cfg.Backend.Retry.Jitter = "none"      // deterministic
 		}),
 	)
 }
@@ -205,8 +205,8 @@ func newRetryAfterServer(failN int) *retryAfterServer {
 	return s
 }
 
-func (s *retryAfterServer) Close() { s.srv.Close() }
-func (s *retryAfterServer) URL() string { return s.srv.URL }
+func (s *retryAfterServer) Close()        { s.srv.Close() }
+func (s *retryAfterServer) URL() string   { return s.srv.URL }
 func (s *retryAfterServer) requests() int { return int(atomic.LoadInt32(&s.called)) }
 
 func (s *retryAfterServer) handle(w http.ResponseWriter, r *http.Request) {

--- a/test/conformance/retry_test.go
+++ b/test/conformance/retry_test.go
@@ -65,6 +65,32 @@ func startRetryGatewayAt(t *testing.T, backendURL string) *harness.Gateway {
 	)
 }
 
+// startRetryGatewayChunked is startRetryGateway with chunked encryption on, so
+// PutObject receives a streaming ciphertext reader rather than a *bytes.Reader.
+// Every other retry case here runs with the harness default (chunking off),
+// which yields a seekable body and therefore never exercises rewind-on-retry.
+func startRetryGatewayChunked(t *testing.T, toxic *toxicServer) *harness.Gateway {
+	t.Helper()
+	inst := provider.Instance{
+		Endpoint:     toxic.URL(),
+		Region:       "us-east-1",
+		AccessKey:    "retry-access",
+		SecretKey:    "retry-secret",
+		Bucket:       "retry-bucket",
+		ProviderName: "retry-chaos",
+	}
+	return harness.StartGateway(t, inst,
+		harness.WithChunking(true),
+		harness.WithConfigMutator(func(cfg *internalconfig.Config) {
+			cfg.Backend.UsePathStyle = true
+			cfg.Backend.UseSSL = false
+			cfg.Backend.Retry.InitialBackoff = 1e6
+			cfg.Backend.Retry.MaxBackoff = 10e6
+			cfg.Backend.Retry.Jitter = "none"
+		}),
+	)
+}
+
 // retryMetricSeries returns the total number of time-series registered for a
 // given metric name in the gateway's isolated registry.  Returns 0 if absent.
 func retryMetricSeries(t *testing.T, gw *harness.Gateway, metricName string) int {
@@ -221,6 +247,28 @@ func testRetry_TransientBackend503_MetricEmitted(t *testing.T, _ provider.Instan
 	// s3_backend_retries_total must have at least one time-series recorded.
 	if retryMetricSeries(t, gw, "s3_backend_retries_total") == 0 {
 		t.Error("s3_backend_retries_total: no series after 503 retries; retry metrics not wired")
+	}
+}
+
+// testRetry_ChunkedPut_TransientBackend503 is the same gate with chunked
+// encryption on. The ciphertext reader is not seekable, so unless the handler
+// buffers it the SDK cannot rewind the body and the retry fails with
+// "failed to rewind transport stream for retry" instead of succeeding.
+func testRetry_ChunkedPut_TransientBackend503(t *testing.T, _ provider.Instance) {
+	t.Helper()
+	backend := newToxicServer()
+	defer backend.Close()
+	gw := startRetryGatewayChunked(t, backend)
+
+	backend.reset()
+	backend.setBehavior(0, 2, http.StatusServiceUnavailable) // 2 failures then succeed
+
+	resp := putToGateway(t, gw, "retry-bucket", "503-chunked-key", []byte("chunked-payload"))
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 after retries on a chunked PUT, got %d", resp.StatusCode)
+	}
+	if n := backend.totalRequests(); n < 3 {
+		t.Errorf("expected ≥3 backend requests (2 retries + 1 success), got %d", n)
 	}
 }
 

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -217,6 +217,7 @@ func TestConformance(t *testing.T) {
 				// These use an in-process ToxicServer backend so no Docker is required.
 				// They verify Prometheus metric emission end-to-end (not just unit-test level).
 				{"PERF2_Retry_503_MetricEmitted", 0, testRetry_TransientBackend503_MetricEmitted},
+				{"PERF2_Retry_503_ChunkedPut", 0, testRetry_ChunkedPut_TransientBackend503},
 				{"PERF2_Retry_429_MetricEmitted", 0, testRetry_TransientBackend429_MetricEmitted},
 				{"PERF2_Retry_GiveUp_MetricEmitted", 0, testRetry_PersistentFailure_GiveUpMetricEmitted},
 				{"PERF2_Retry_BackoffHistogram", 0, testRetry_BackoffHistogramPopulated},


### PR DESCRIPTION
A chunked-encrypted upload hands PutObject a streaming ciphertext reader, which is not an io.Seeker. The AWS SDK rewinds the request body before a retry, so on that path every retryable backend failure aborted with "failed to rewind transport stream for retry, request stream is not seekable" instead of being retried. ADR 0010's retry policy was therefore inert on the one path that carries every ordinary write: the retryer classified the error as retryable, counted the attempt, and then the operation failed before the second request left the process.

The visible effect is that a transient backend 500 reaches the client as a hard error. Measured against Backblaze B2 this was ~3% of uploads, and the client's own retry of the whole write costs more backend requests than a retried PutObject would.

PutObject bodies of known length now go through the same bounded SeekableBody wrapper handleUploadPart already uses, capped by server.max_part_buffer. The gate is on a known length that fits the cap because NewSeekableBody drains maxBuf+1 bytes before reporting ErrPartTooLarge, leaving no way back to streaming; that also keeps the buffer disjoint from ciphertextCounter, which is installed exactly when the length is unknown. Unknown-length bodies keep the streaming path and stay single-attempt by design.

Because the body is now seekable, these requests also carry Content-MD5 and a signed payload rather than UNSIGNED-PAYLOAD; both fall out of the same type assertion in s3Client.PutObject and match what UploadPart has always sent.

The existing retry conformance tests never caught this: harness.StartGateway defaults chunking off, which yields a *bytes.Reader that rewinds fine, and harness.WithChunking had no call sites. Adds PERF2_Retry_503_ChunkedPut to close that gap, handler-level coverage that fails without this change, and internal/s3 tests pinning the rewind contract in both directions.

Refs ADR 0010 and docs/plans/V0.6-PERF-1-plan.md §4.4.

Measured on a production gateway in front of Backblaze B2, where ~1–3% of `PutObject`
calls return a transient `500 InternalError`:

| | before | after (32h, 5,643 PUTs) |
|---|---|---|
| client-facing PUT failures | **3.07%** | **0** |
| `s3_operation_errors_total{operation="PutObject",error_type="InternalError"}` | climbing | 0 |
| backend `internal_500` retries absorbed | 0 | 101 |

An unpatched gateway of the same version against the same backend is the control, and
there the correspondence is exactly 1:1 — 7 `internal_500` retries → 7 surfaced
`PutObject` errors, and 3 → 3. Every classified retry became a client-visible failure.
On the patched build, 101 retries produced zero.