### PR TITLE
fix(helm): remove invalid insecureSkipTLSVerify field from probes

### DIFF
--- a/helm/s3-encryption-gateway/templates/deployment.yaml
+++ b/helm/s3-encryption-gateway/templates/deployment.yaml
@@ -367,7 +367,6 @@ spec:
             httpHeaders:
               {{- toYaml .Values.livenessProbe.httpGet.httpHeaders | nindent 14 }}
             {{- end }}
-            insecureSkipTLSVerify: true
           {{- if .Values.livenessProbe.initialDelaySeconds }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           {{- end }}
@@ -396,7 +395,6 @@ spec:
             httpHeaders:
               {{- toYaml .Values.readinessProbe.httpGet.httpHeaders | nindent 14 }}
             {{- end }}
-            insecureSkipTLSVerify: true
           {{- if .Values.readinessProbe.initialDelaySeconds }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           {{- end }}


### PR DESCRIPTION
The chart renders `insecureSkipTLSVerify: true` inside the httpGet block of both livenessProbe and readinessProbe when TLS is enabled. This field is not part of the Kubernetes HTTPGetAction API, so the API server prunes it and the live object never matches the rendered manifest. GitOps tools that diff desired against live state therefore report permanent drift on the Deployment.

The field is also unnecessary: the kubelet's HTTPS prober does not validate the server certificate, so probes against a self-signed gateway certificate succeed without it.

Fixes #289

---

## Before

```console
$ helm template s3-encryption-gateway ./helm/s3-encryption-gateway \
  --set-string config.tls.enabled.value=true \
  --set-string config.tls.certFile.value=/etc/gateway-tls/tls.crt \
  --set-string config.tls.keyFile.value=/etc/gateway-tls/tls.key \
  | grep -A6 -e livenessProbe -e readinessProbe
        livenessProbe:
          httpGet:
            path: /live
            port: http
            scheme: HTTPS
            insecureSkipTLSVerify: true
          initialDelaySeconds: 10
--
        readinessProbe:
          httpGet:
            path: /ready
            port: http
            scheme: HTTPS
            insecureSkipTLSVerify: true
          initialDelaySeconds: 5
```

## After

```console
helm template s3-encryption-gateway ./helm/s3-encryption-gateway \
  --set-string config.tls.enabled.value=true \
  --set-string config.tls.certFile.value=/etc/gateway-tls/tls.crt \
  --set-string config.tls.keyFile.value=/etc/gateway-tls/tls.key \
  | grep -A6 -e livenessProbe -e readinessProbe
        livenessProbe:
          httpGet:
            path: /live
            port: http
            scheme: HTTPS
          initialDelaySeconds: 10
          periodSeconds: 30
--
        readinessProbe:
          httpGet:
            path: /ready
            port: http
            scheme: HTTPS
          initialDelaySeconds: 5
          periodSeconds: 10
```